### PR TITLE
add parametro notification_log_id no read notification

### DIFF
--- a/DitoSDK/DitoSDK/DitoAPI.m
+++ b/DitoSDK/DitoSDK/DitoAPI.m
@@ -418,6 +418,12 @@ static DitoCredentials *credentialsOffLine;
     [params setValue:[self getIdentifyKey:credentials] forKey:kIdType];
     [params setValue:[self getSocialID:credentials] forKey:@"id"];
     
+    if(jsonMessage[@"notification_log_id"]){
+      NSString *notificationLogId = @"";
+      notificationLogId = jsonMessage[@"notification_log_id"]
+      [params setValue:notificationLogId forKey:@"notification_log_id"];
+    }
+    
     [self peformRequest:POST url:url params:params completion:block];
 }
 


### PR DESCRIPTION
Foi adicionado o parâmetro notification_log_id na requisição que manda o open notification. Esse parâmetro é essencial pra Dito saber de qual disparo foi a abertura.